### PR TITLE
fix: mask shape zero error

### DIFF
--- a/gen2-facemesh/utils/effect.py
+++ b/gen2-facemesh/utils/effect.py
@@ -12,6 +12,15 @@ class EffectRenderer2D:
         filter_points_path: str = "./res/filter_points.npy",
         use_filter_points: bool = True,
     ):
+        """Initialize EffectRenderer2D.
+
+        Args:
+            effect_image_path (str): path to the effect image (1024 x 1024)
+            src_points_path (str, optional): path to the source landmarks. Defaults to "./res/source_landmarks.npy".
+            filter_points_path (str, optional): path to the filter landmarks. Defaults to "./res/filter_points.npy".
+            use_filter_points (bool, optional): use filter landmarks. Defaults to True.
+        """
+
         self.effect_image = cv2.imread(effect_image_path, cv2.IMREAD_UNCHANGED)
         height, width, _ = self.effect_image.shape
 
@@ -81,15 +90,15 @@ class EffectRenderer2D:
                 borderMode=cv2.BORDER_REFLECT_101,
             )
 
-            mask = np.zeros((overlay_crop.shape[0], overlay_crop.shape[1], 4), dtype=np.uint8)
+            mask = np.zeros((overlay_crop.shape[0], overlay_crop.shape[1], 4), dtype=np.uint8)  # shapeが一つでも0になるとエラーになる
+            if mask.shape[0] != 0 and mask.shape[1] != 0:
+                cv2.fillConvexPoly(
+                    mask, np.int32(dst_tri_crop), (1.0, 1.0, 1.0, 1.0), 16, 0
+                )  # 多角形を描画 fillConvexPoly(元の画像, 複数の座標, color, ...)
+                mask[np.where(overlay_crop > 0)] = 0
 
-            cv2.fillConvexPoly(
-                mask, np.int32(dst_tri_crop), (1.0, 1.0, 1.0, 1.0), 16, 0
-            )  # 多角形を描画 fillConvexPoly(元の画像, 複数の座標, color, ...)
-            mask[np.where(overlay_crop > 0)] = 0
-
-            cropped_triangle = warp * mask
-            overlay_crop += cropped_triangle
+                cropped_triangle = warp * mask
+                overlay_crop += cropped_triangle
 
         return overlay
 

--- a/i-make/libs/effect.py
+++ b/i-make/libs/effect.py
@@ -12,6 +12,15 @@ class EffectRenderer2D:
         filter_points_path: str = "i-make/res/filter_points.npy",
         use_filter_points: bool = True,
     ):
+        """Initialize EffectRenderer2D.
+
+        Args:
+            effect_image_path (str): path to the effect image (1024 x 1024)
+            src_points_path (str, optional): path to the source landmarks. Defaults to "i-make/res/source_landmarks.npy".
+            filter_points_path (str, optional): path to the filter landmarks. Defaults to "i-make/res/filter_points.npy".
+            use_filter_points (bool, optional): use filter landmarks. Defaults to True.
+        """
+
         self.effect_image = cv2.imread(effect_image_path, cv2.IMREAD_UNCHANGED)
         height, width, _ = self.effect_image.shape
 
@@ -81,15 +90,15 @@ class EffectRenderer2D:
                 borderMode=cv2.BORDER_REFLECT_101,
             )
 
-            mask = np.zeros((overlay_crop.shape[0], overlay_crop.shape[1], 4), dtype=np.uint8)
+            mask = np.zeros((overlay_crop.shape[0], overlay_crop.shape[1], 4), dtype=np.uint8)  # shapeが一つでも0になるとエラーになる
+            if mask.shape[0] != 0 and mask.shape[1] != 0:
+                cv2.fillConvexPoly(
+                    mask, np.int32(dst_tri_crop), (1.0, 1.0, 1.0, 1.0), 16, 0
+                )  # 多角形を描画 fillConvexPoly(元の画像, 複数の座標, color, ...)
+                mask[np.where(overlay_crop > 0)] = 0
 
-            cv2.fillConvexPoly(
-                mask, np.int32(dst_tri_crop), (1.0, 1.0, 1.0, 1.0), 16, 0
-            )  # 多角形を描画 fillConvexPoly(元の画像, 複数の座標, color, ...)
-            mask[np.where(overlay_crop > 0)] = 0
-
-            cropped_triangle = warp * mask
-            overlay_crop += cropped_triangle
+                cropped_triangle = warp * mask
+                overlay_crop += cropped_triangle
 
         return overlay
 


### PR DESCRIPTION
# Overview <!-- What is the change -->
> MULTI_FACE_LANDMARKS
Collection of detected/tracked faces, where each face is represented as a list of 468 face landmarks and each landmark is composed of x, y and z. x and y are normalized to [0.0, 1.0] by the image width and height respectively. z represents the landmark depth with the depth at center of the head being the origin, and the smaller the value the closer the landmark is to the camera. The magnitude of z uses roughly the same scale as x.

とあるが、1を超えるy座標が帰ってきていることがあった。そのため、元の画像のshapeを超えたインデックス指定をしてしまい、shapeが0を含んだmaskが生成されエラーが発生していた。

# Issue number <!-- e.g. Close #123, Fix #456 -->
Close #17 


# How to check the revision
1. 

# Points for Review <!-- Things you want reviewers to check, etc. -->


# Remarks <!-- Any other comments -->


<!-- You don't have to fill in all the blanks, but write the necessary information clearly. -->